### PR TITLE
Correct dff

### DIFF
--- a/problems/03/slave.v
+++ b/problems/03/slave.v
@@ -8,9 +8,9 @@ reg [3:0] bit_counter;
 
 always @(posedge sclk)
 begin
-	shift_regs[0] <= mosi;
 	if (bit_counter == 8)
 	begin
+		shift_regs[0] <= mosi;
 		bit_counter <= 0;
 		data_indikators <= shift_regs;
 	end


### PR DESCRIPTION
У тебя 13 строчка была вне ифа, таким образом у тебя при счетчике равным 8 происходила два опрделенеия нулевого бита shift_regs, а это не синтезируемо, несколько драйверов на один вход